### PR TITLE
phal: add FFDC parser API for PFUT

### DIFF
--- a/libekb.C
+++ b/libekb.C
@@ -18,6 +18,7 @@ extern "C" {
 #include <return_code.H>
 #include <set_sbe_error.H>
 
+#include <cstring>
 #include <vector>
 
 static libekb_log_func_t __libekb_log_fn;
@@ -174,7 +175,6 @@ void libekb_get_ffdc_helper(FFDC& ffdc, fapi2::ReturnCode& rc)
 		    "No FFDC, libekb_get_ffdc() called for success case";
 		return;
 	}
-
 	if (rc.getCreator() == fapi2::ReturnCode::CREATOR_HWP) {
 		ffdc.ffdc_type = FFDC_TYPE_HWP;
 		get_HWPErrorInfo(rc, ffdc.hwp_errorinfo);
@@ -265,4 +265,48 @@ void libekb_get_sbe_ffdc(FFDC& ffdc, const sbeFfdcPacketType& ffdc_pkt,
 	// For clock hwp error happened inside SBE context, the proc
 	// target should not to be deconfigured
 	fapi2::process_HW_callout(ffdc, false);
+}
+
+void libekb_parse_sbe_ffdc_pkt(uint32_t fapiRc,
+			       const std::vector<uint8_t>& blobData,
+			       int chipPos, uint32_t sbeChipType, FFDC& ffdc)
+{
+	using namespace fapi2;
+	libekb_log(LIBEKB_LOG_INF,
+		   "chip pos: %d  chip type 0x%08X  fapirc: 0x%x length: %zu\n",
+		   chipPos, sbeChipType, fapiRc, blobData.size());
+
+	constexpr size_t sbeFfdcSize = sizeof(sbeFfdc_t);
+	std::vector<sbeFfdc_t> ffdc_endian;
+	const sbeFfdc_t* sbe_ffdc =
+	    reinterpret_cast<const sbeFfdc_t*>(blobData.data());
+	size_t size = blobData.size();
+	// Parse and convert all entries
+	for (size_t i = 0; i < size; i += sbeFfdcSize, sbe_ffdc++) {
+		sbeFfdc_t ffdc_data;
+		ffdc_data.size = ntohl(sbe_ffdc->size);
+		// Special type FFDC size need endianess conversion in data.
+		// TODO: Endianess for size "1, 2, 4" need to revisit.
+		if ((ffdc_data.size == EI_FFDC_SIZE_TARGET) ||
+		    (ffdc_data.size == EI_FFDC_SIZE_BUF) ||
+		    (ffdc_data.size == EI_FFDC_SIZE_VBUF) ||
+		    (ffdc_data.size == EI_FFDC_MAX_SIZE)) {
+			ffdc_data.data = be64toh(sbe_ffdc->data);
+		} else {
+			ffdc_data.data = sbe_ffdc->data;
+		}
+		ffdc_endian.push_back(ffdc_data);
+	}
+	// Convert to FAPI RC
+	fapi2::ReturnCode rc;
+	if (ffdc_endian.size() > 0) {
+		FAPI_SET_SBE_ERROR(rc, fapiRc, ffdc_endian.data(), chipPos,
+				   static_cast<fapi2::TargetType>(sbeChipType));
+
+		libekb_log(LIBEKB_LOG_INF, " New FAPI RC: 0x%x\n", rc);
+
+		// Fill FFDC struct
+		libekb_get_ffdc_helper(ffdc, rc);
+		fapi2::process_HW_callout(ffdc, false);
+	}
 }

--- a/libekb.H
+++ b/libekb.H
@@ -1,6 +1,7 @@
 #ifndef __LIBEKB_H__
 #define __LIBEKB_H__
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -14,6 +15,7 @@
 
 extern "C" {
 #include <stdarg.h>
+
 #include <cstdint>
 
 typedef void (*libekb_log_func_t)(void *private_data, const char *fmt,
@@ -160,9 +162,9 @@ struct FFDC {
  * @brief SBE FFDC packet
  */
 typedef struct sbeFfdcPacket {
-	uint32_t fapiRc;	    // Fapi Rc
-	uint32_t ffdcLengthInWords; // length of Fapi FFDC data
-	uint32_t *ffdcData = nullptr;	    // fapi FFDC data
+	uint32_t fapiRc;	      // Fapi Rc
+	uint32_t ffdcLengthInWords;   // length of Fapi FFDC data
+	uint32_t *ffdcData = nullptr; // fapi FFDC data
 	~sbeFfdcPacket()
 	{
 		// freeup the ffdcData allocated memory
@@ -201,4 +203,8 @@ void libekb_get_ffdc(FFDC &ffdc);
  */
 void libekb_get_sbe_ffdc(FFDC &ffdc, const sbeFfdcPacketType &ffdc_pkt,
 			 int chipPos, uint32_t sbeChipType);
+
+void libekb_parse_sbe_ffdc_pkt(uint32_t fapiRc,
+			       const std::vector<uint8_t> &blobData,
+			       int chipPos, uint32_t sbeChipType, FFDC &ffdc);
 #endif /* __LIBEKB_H__ */


### PR DESCRIPTION
…L creation

Introduced a new API to parse SBE FFDC data specifically for PFUT scenarios. With the shift to using error objects for PEL creation, the caller now receives error objects containing FFDC, which are parsed to extract relevant data.

Updated libekb to align with the new error handling mechanism, ensuring FFDC parsing and PEL generation work seamlessly with the updated interface.

Tested:
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "HWP_FFDC_INVALID_ERRVAL": "000c0af0",
    "HWP_FFDC_Unrecognized FFDC": "fbad0039 01a80000 00000400 000c0af0 00000000 4910957a ff000000 04000000 38100400 00020000 5f454253 43415254 45000000 00000000 0f300000 38131000 af2923fe 0046c323 00000000 ffffffff 8ffa73ef 00000018 d85f0100 00000000 00000000 01018d2c 063e5c9d 5fd60000 11435c9d 060039a6 9f4d53a9 7ada0000 00000000 d0a40102 1e564d9f 00000000 00000001 02019cc4 da584d9f 91a00006 f15a4d9f 000020c9 9f4d6021 01000000 00000000 eb800102 c6614d9f a2000000 00000001 0201771f 36c1629f 000000a2 01000000 0201f1f0 9f62c392 03000000 addeadde 01017fec 62e6b3af 0000d65f",
    "HWP_RC": "RC_ERROR_UNSUPPORTED_BY_SBE",
    "HWP_RC_DESC": "An error was encountered that the SBE didn't expect.",
    "SRC6": "0"
},